### PR TITLE
feat: End time saving account 페이지 구현

### DIFF
--- a/frontend/components/Slider/SavingMoneySlider.tsx
+++ b/frontend/components/Slider/SavingMoneySlider.tsx
@@ -8,15 +8,18 @@ import LongButton from '../ButtonItems/LongButton';
 const {width:SCREEN_WIDTH} = Dimensions.get("window");
 
 const SavingMoneySlider = () => {
-  const [Participants, setParticipants] = useState([
+    const loginUser = "tksgk2598";
+    const [Participants, setParticipants] = useState([
     {
+        userId : "sdy",
         userName: "신산하",
         profileImg: 'https://picsum.photos/100/100',
         money: "8,000",
         isHost: true,
-        type: "receive" //send or receive
+        type: "send" //send or receive
       },
       {
+        userId : "sdy",
         userName: "석다영",
         profileImg: 'https://picsum.photos/100/100',
         money: "2,000",
@@ -24,6 +27,7 @@ const SavingMoneySlider = () => {
         type: "receive" //send or receive
       },
       {
+        userId : "kms",
         userName: "김민식",
         profileImg: 'https://picsum.photos/100/100',
         money: "5,000",
@@ -31,6 +35,7 @@ const SavingMoneySlider = () => {
         type: "receive" //send or receive
       },
       {
+        userId : "lsh",
         userName: "이승현",
         profileImg: 'https://picsum.photos/100/100',
         money: "5,000",
@@ -71,7 +76,7 @@ const SavingMoneySlider = () => {
                             people.type==="receive"?
                                 <Text style={tw`text-[20px] font-bold mt-1 text-white`}>아래 금액을 받아야 합니다.</Text>
                                 :
-                                <Text style={tw`text-[20px] font-bold mt-1 text-white`}>주최자님께 아래 금액을 드려야 합니다.</Text>
+                                <Text style={tw`text-[20px] font-bold mt-1 text-white`}>아래 금액을 드려야 합니다.</Text>
 
                         }
                     </View>
@@ -81,8 +86,21 @@ const SavingMoneySlider = () => {
                     </View>
 
                     <View style={tw`flex-1 flex-row`}>
-                        <LongButton content='보내기'/>
-                        <LongButton content='랜덤정산'/>
+                        {
+                            // receive : 방장이 사람들에게 돈을 보내야 함 (방장이 보내기 진행)
+                            // send : 사람들이 방장한테 돈을 보내야 함 (방장이 돈 달라고 요청)
+                            // null : 내가 방장이면 아무것도 안뜸
+                           
+                                people.type==="receive" && !people.isHost?<LongButton content='보내기'/>:
+                                (
+                                    people.type==="send" && !people.isHost?<LongButton content='보내기'/>:null
+                                )
+                                
+                            
+                            
+                                
+                        }
+                        {loginUser!==people.userId?null:<LongButton content='랜덤정산'/>}
                     </View>
                 </View>
               );

--- a/frontend/components/Slider/SavingMoneySlider.tsx
+++ b/frontend/components/Slider/SavingMoneySlider.tsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, Text, View, ScrollView,  Dimensions, Image } from 'react-native';
+import tw from 'twrnc';
+
+// 컴포넌트
+import LongButton from '../ButtonItems/LongButton';
+
+const {width:SCREEN_WIDTH} = Dimensions.get("window");
+
+const SavingMoneySlider = () => {
+  const [Participants, setParticipants] = useState([
+    {
+        userName: "신산하",
+        profileImg: 'https://picsum.photos/100/100',
+        money: "8,000",
+        isHost: true,
+        type: "receive" //send or receive
+      },
+      {
+        userName: "석다영",
+        profileImg: 'https://picsum.photos/100/100',
+        money: "2,000",
+        isHost: false,
+        type: "receive" //send or receive
+      },
+      {
+        userName: "김민식",
+        profileImg: 'https://picsum.photos/100/100',
+        money: "5,000",
+        isHost: false,
+        type: "receive" //send or receive
+      },
+      {
+        userName: "이승현",
+        profileImg: 'https://picsum.photos/100/100',
+        money: "5,000",
+        isHost: false,
+        type: "receive" //send or receive
+      }
+  ]);
+
+
+  return (
+    <View style={[tw`flex-1`, { backgroundColor: 'rgba(11, 11, 59, 0.5)'}]}>
+
+
+      <ScrollView 
+        pagingEnabled
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={tw`mt-[40px]`}>
+
+        {
+          Participants.length === 0?(
+            <View style={styles.slider}>
+                <Text style={tw`text-[30px] font-bold text-white items-center mt-[40%]`}>참여자 정보가 없습니다.</Text>
+            </View>
+          ):(
+            Participants.map((people, index)=>{
+              return(
+                <View key={index} style={styles.slider}>
+                    
+                    <View style={tw`flex-col items-center justify-center w-full`}>
+                        <Image
+                                style={tw`w-20 h-20 rounded-full`}
+                                source={{ uri: 'https://picsum.photos/100/100' }}
+                                resizeMode="cover"
+                        />
+                        <Text style={tw`text-[20px] mt-2 font-bold text-white`}>{people.userName} 님</Text>
+                        {
+                            people.type==="receive"?
+                                <Text style={tw`text-[20px] font-bold mt-1 text-white`}>아래 금액을 받아야 합니다.</Text>
+                                :
+                                <Text style={tw`text-[20px] font-bold mt-1 text-white`}>주최자님께 아래 금액을 드려야 합니다.</Text>
+
+                        }
+                    </View>
+
+                    <View style={tw`items-center mt-10`}>
+                        <Text style={tw`text-[50px] font-3xl font-bold text-white`}>{people.money} 원</Text>
+                    </View>
+
+                    <View style={tw`flex-1 flex-row`}>
+                        <LongButton content='보내기'/>
+                        <LongButton content='랜덤정산'/>
+                    </View>
+                </View>
+              );
+            })
+          )
+        }
+      
+      </ScrollView>
+
+      
+    </View>
+  );
+}
+
+export default SavingMoneySlider;
+
+const styles = StyleSheet.create({
+    slider:{
+      width:SCREEN_WIDTH,
+      alignItems:"center",
+    },
+  });

--- a/frontend/components/Slider/SavingMoneySlider.tsx
+++ b/frontend/components/Slider/SavingMoneySlider.tsx
@@ -9,14 +9,15 @@ const {width:SCREEN_WIDTH} = Dimensions.get("window");
 
 const SavingMoneySlider = () => {
     const loginUser = "tksgk2598";
+    const hostUser = "tksgk2598";
     const [Participants, setParticipants] = useState([
     {
-        userId : "sdy",
+        userId : "tksgk2598",
         userName: "신산하",
         profileImg: 'https://picsum.photos/100/100',
         money: "8,000",
         isHost: true,
-        type: "send" //send or receive
+        type: "receive" //send or receive
       },
       {
         userId : "sdy",
@@ -87,20 +88,20 @@ const SavingMoneySlider = () => {
 
                     <View style={tw`flex-1 flex-row`}>
                         {
-                            // receive : 방장이 사람들에게 돈을 보내야 함 (방장이 보내기 진행)
-                            // send : 사람들이 방장한테 돈을 보내야 함 (방장이 돈 달라고 요청)
+                          // 방장입장에서만 생각하자. 왜냐하면 참여자들은 신한 계좌가 없다고 생각해야 하기 떄문이다.
+                            // receive : 방장이 돈을 받아야 한다
+                            // send : 방장이 돈을 보내야 한다
                             // null : 내가 방장이면 아무것도 안뜸
-                           
-                                people.type==="receive" && !people.isHost?<LongButton content='보내기'/>:
-                                (
-                                    people.type==="send" && !people.isHost?<LongButton content='보내기'/>:null
+                              loginUser!==hostUser? null : (
+                                people.type==="send" && !people.isHost ?<LongButton content='보내기'/>:(
+                                  people.type==="receive" && !people.isHost?<LongButton content='요청하기'/>:null
                                 )
-                                
-                            
-                            
-                                
+                              )
+      
+
                         }
-                        {loginUser!==people.userId?null:<LongButton content='랜덤정산'/>}
+                        {/* 현재 상황에서는 랜덤정산 생략하자 시간 남으면 진행 */}
+                        {/* <LongButton content='랜덤정산'/>  */}
                     </View>
                 </View>
               );

--- a/frontend/navigation/AppNavigation.tsx
+++ b/frontend/navigation/AppNavigation.tsx
@@ -45,7 +45,15 @@ const AppNavigation = () => {
           }}
           />
         <Stack.Screen name='EndTimeReset' component={EndTimeReset} />
-        <Stack.Screen name='EndTimeHistory' component={EndTimeHistory} />
+        <Stack.Screen name='EndTimeHistory' component={EndTimeHistory} 
+          options={{
+            headerTransparent : true, 
+            headerBackTitleVisible : true,
+            headerLeft : () => (
+                <BackButton></BackButton>
+            )
+          }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   )

--- a/frontend/navigation/AppNavigation.tsx
+++ b/frontend/navigation/AppNavigation.tsx
@@ -10,6 +10,7 @@ import { useNavigation } from '@react-navigation/native'
 import { Entypo } from '@expo/vector-icons';
 import EndTimeReset from '../screens/EndTimeReset';
 import EndTimeHistory from '../screens/EndTimeHistory';
+import EndTimeSavingMoney from '../screens/EndTimeSavingMoney';
 
 const Stack = createNativeStackNavigator();
 //뒤로가기 버튼 컴포넌트
@@ -45,15 +46,8 @@ const AppNavigation = () => {
           }}
           />
         <Stack.Screen name='EndTimeReset' component={EndTimeReset} />
-        <Stack.Screen name='EndTimeHistory' component={EndTimeHistory} 
-          options={{
-            headerTransparent : true, 
-            headerBackTitleVisible : true,
-            headerLeft : () => (
-                <BackButton></BackButton>
-            )
-          }}
-        />
+        <Stack.Screen name='EndTimeHistory' component={EndTimeHistory} options={{headerShown:false}}/>
+        <Stack.Screen name='EndTimeSavingMoney' component={EndTimeSavingMoney} options={{headerShown:false}}/>
       </Stack.Navigator>
     </NavigationContainer>
   )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,14 +17,13 @@
         "expo-linking": "~5.0.2",
         "expo-router": "2.0.0",
         "expo-status-bar": "~1.6.0",
-        "ionicons": "^7.1.2",
         "react": "18.2.0",
         "react-native": "0.72.4",
         "react-native-animatable": "^1.3.3",
         "react-native-chart-kit": "^6.12.0",
         "react-native-chart-kit-chz": "^1.1.2",
         "react-native-gesture-handler": "~2.12.0",
-        "react-native-linear-gradient": "^2.8.2",
+        "react-native-linear-gradient": "^2.8.3",
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0",
         "react-native-svg": "^13.13.0",
@@ -6070,18 +6069,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@stencil/core": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
-      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@types/hammerjs": {
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
@@ -9027,14 +9014,6 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dependencies": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/ionicons": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.2.tgz",
-      "integrity": "sha512-zZ4njAqSP39H8RRvZhJvkHsv7cBjYE/VfInH218Osf2UVxJITSOutTTd25MW+tAXKN5fheYzclUXUsF55JHUDg==",
-      "dependencies": {
-        "@stencil/core": "^2.18.0"
       }
     },
     "node_modules/ip": {
@@ -13057,9 +13036,9 @@
       }
     },
     "node_modules/react-native-linear-gradient": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.2.tgz",
-      "integrity": "sha512-hgmCsgzd58WNcDCyPtKrvxsaoETjb/jLGxis/dmU3Aqm2u4ICIduj4ECjbil7B7pm9OnuTkmpwXu08XV2mpg8g==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz",
+      "integrity": "sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react-native-chart-kit": "^6.12.0",
     "react-native-chart-kit-chz": "^1.1.2",
     "react-native-gesture-handler": "~2.12.0",
-    "react-native-linear-gradient": "^2.8.2",
+    "react-native-linear-gradient": "^2.8.3",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-svg": "^13.13.0",

--- a/frontend/screens/EndTimeHistory.tsx
+++ b/frontend/screens/EndTimeHistory.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, ImageBackground, SafeAreaView, ScrollView, TouchableOpacity } from 'react-native';
 import tw from 'twrnc';
 import * as Animatable from 'react-native-animatable'; // 애니메이션 라이브러리 추가
+import { StackNavigationProp } from '@react-navigation/stack';
 
 // 이미지
 import starrynight from '../assets/images/starrynight_bg.jpg';
@@ -11,10 +12,18 @@ import EndTimeGraph from '../components/Graph/EndTimeGraph';
 import LongButton from '../components/ButtonItems/LongButton';
 import EndTimeBarGraph from '../components/Graph/EndTimeBarGraph';
 
-function EndTimeHistory() {
+type EndTimeHistoryProps = {
+  navigation: StackNavigationProp<any>;
+};
+
+const EndTimeHistory:React.FC<EndTimeHistoryProps> = ({navigation}) => {
   const [animation1, setAnimation1] = useState(null);
   const [animation2, setAnimation2] = useState(null);
   const [animation3, setAnimation3] = useState(null);
+
+  const handleSavingMoney = () => {
+    navigation.navigate("EndTimeSavingMoney");
+  }
 
   useEffect(() => {
     if (animation1) animation1.slideInUp(1000); // 첫 번째 애니메이션
@@ -66,7 +75,7 @@ function EndTimeHistory() {
       </View>
 
       <View style={tw `flex-0.7 flex-row items-end justify-center`}>
-        <LongButton content='다음' />
+        <LongButton content='다음' onPress={handleSavingMoney} />
       </View>
     </View>
   );

--- a/frontend/screens/EndTimeSavingMoney.tsx
+++ b/frontend/screens/EndTimeSavingMoney.tsx
@@ -6,6 +6,9 @@ import { Ionicons } from "@expo/vector-icons";
 // 이미지
 import starrynight from '../assets/images/starrynight_bg.jpg';
 
+//컴포넌트
+import SavingMoneySlider from '../components/Slider/SavingMoneySlider';
+
 const EndTimeSavingMoney = () => {
     
     const [saving, setSaving] = useState("20,000");
@@ -19,8 +22,8 @@ const EndTimeSavingMoney = () => {
                 <Text style={tw `text-5xl font-bold text-white`}>{saving}원</Text>
             </View>
 
-            <View style={tw `flex-3 bg-orange-100`}>
-
+            <View style={tw `flex-3 items-center justify-center`}>
+                <SavingMoneySlider/>
             </View>
 
             <View style={tw `flex-1 bg-blue-100`}>

--- a/frontend/screens/EndTimeSavingMoney.tsx
+++ b/frontend/screens/EndTimeSavingMoney.tsx
@@ -1,17 +1,30 @@
 import React, { useState, useEffect } from 'react';
 import {View, Text, ImageBackground} from 'react-native';
 import tw from 'twrnc'; 
-import { Ionicons } from "@expo/vector-icons";
+import { StackNavigationProp } from '@react-navigation/stack';
 
 // 이미지
 import starrynight from '../assets/images/starrynight_bg.jpg';
 
 //컴포넌트
 import SavingMoneySlider from '../components/Slider/SavingMoneySlider';
+import LongButton from '../components/ButtonItems/LongButton';
 
-const EndTimeSavingMoney = () => {
+
+type EndTimeSavingMoneyProps = {
+    navigation: StackNavigationProp<any>;
+};
+
+const EndTimeSavingMoney:React.FC<EndTimeSavingMoneyProps> = ({navigation}) => {
     
     const [saving, setSaving] = useState("20,000");
+
+    const handleSavingMoney = () => {
+        navigation.navigate("EndTimeHistory");
+    }
+    // const handleSavingMoney = () => {
+    //     navigation.navigate("EndTimeSavingMoney");
+    // }
 
     return(
         <View style={tw`flex-1`}>
@@ -26,8 +39,9 @@ const EndTimeSavingMoney = () => {
                 <SavingMoneySlider/>
             </View>
 
-            <View style={tw `flex-1 bg-blue-100`}>
-
+            <View style={tw `flex-1 flex-row`}>
+                <LongButton content='이전' onPress={handleSavingMoney}/>
+                <LongButton content='다음'/>
             </View>
         </View>
     )

--- a/frontend/screens/EndTimeSavingMoney.tsx
+++ b/frontend/screens/EndTimeSavingMoney.tsx
@@ -1,0 +1,13 @@
+import {View, Text} from 'react-native';
+import tw from 'twrnc'; 
+import { Ionicons } from "@expo/vector-icons";
+
+const EndTimeSavingMoney = () => {
+    return(
+        <View style={tw`flex-1`}>
+            <Text>하이</Text>
+        </View>
+    )
+}
+
+export default EndTimeSavingMoney

--- a/frontend/screens/EndTimeSavingMoney.tsx
+++ b/frontend/screens/EndTimeSavingMoney.tsx
@@ -35,7 +35,7 @@ const EndTimeSavingMoney:React.FC<EndTimeSavingMoneyProps> = ({navigation}) => {
                 <Text style={tw `text-5xl font-bold text-white`}>{saving}원</Text>
             </View>
 
-            <View style={tw `flex-3 items-center justify-center`}>
+            <View style={tw `flex-4 items-center justify-center`}>
                 <SavingMoneySlider/>
             </View>
 

--- a/frontend/screens/EndTimeSavingMoney.tsx
+++ b/frontend/screens/EndTimeSavingMoney.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {View, Text, ImageBackground} from 'react-native';
 import tw from 'twrnc'; 
 import { StackNavigationProp } from '@react-navigation/stack';
+import * as Animatable from 'react-native-animatable'; // 애니메이션 라이브러리 추가
 
 // 이미지
 import starrynight from '../assets/images/starrynight_bg.jpg';
@@ -26,18 +27,29 @@ const EndTimeSavingMoney:React.FC<EndTimeSavingMoneyProps> = ({navigation}) => {
     //     navigation.navigate("EndTimeSavingMoney");
     // }
 
+    const [animation1, setAnimation1] = useState(null);
+    const [animation2, setAnimation2] = useState(null);
+
+    useEffect(() => {
+        if (animation1) animation1.slideInUp(1000); // 첫 번째 애니메이션
+      }, [animation1]);
+    
+      useEffect(() => {
+        if (animation2) animation2.slideInUp(2000); // 두 번째 애니메이션
+      }, [animation2]);
+
     return(
         <View style={tw`flex-1`}>
-            <ImageBackground source={starrynight} style={tw `w-full h-full bg-cover absolute`}></ImageBackground>
+            <ImageBackground source={starrynight} style={tw `w-full h-full bg-cover absolute`}/>
             
-            <View style={tw `flex-2 justify-center items-center`}>
+            <Animatable.View ref={(ref) => setAnimation1(ref)} style={tw `flex-2 justify-center items-center`}>
                 <Text style={tw `text-xl text-white mt-10`}>동행통장 잔여 금액</Text>
                 <Text style={tw `text-5xl font-bold text-white`}>{saving}원</Text>
-            </View>
+            </Animatable.View>
 
-            <View style={tw `flex-4 items-center justify-center`}>
+            <Animatable.View ref={(ref) => setAnimation2(ref)} style={tw `flex-4 items-center justify-center`}>
                 <SavingMoneySlider/>
-            </View>
+            </Animatable.View>
 
             <View style={tw `flex-1 flex-row`}>
                 <LongButton content='이전' onPress={handleSavingMoney}/>

--- a/frontend/screens/EndTimeSavingMoney.tsx
+++ b/frontend/screens/EndTimeSavingMoney.tsx
@@ -1,11 +1,31 @@
-import {View, Text} from 'react-native';
+import React, { useState, useEffect } from 'react';
+import {View, Text, ImageBackground} from 'react-native';
 import tw from 'twrnc'; 
 import { Ionicons } from "@expo/vector-icons";
 
+// 이미지
+import starrynight from '../assets/images/starrynight_bg.jpg';
+
 const EndTimeSavingMoney = () => {
+    
+    const [saving, setSaving] = useState("20,000");
+
     return(
         <View style={tw`flex-1`}>
-            <Text>하이</Text>
+            <ImageBackground source={starrynight} style={tw `w-full h-full bg-cover absolute`}></ImageBackground>
+            
+            <View style={tw `flex-2 justify-center items-center`}>
+                <Text style={tw `text-xl text-white mt-10`}>동행통장 잔여 금액</Text>
+                <Text style={tw `text-5xl font-bold text-white`}>{saving}원</Text>
+            </View>
+
+            <View style={tw `flex-3 bg-orange-100`}>
+
+            </View>
+
+            <View style={tw `flex-1 bg-blue-100`}>
+
+            </View>
         </View>
     )
 }


### PR DESCRIPTION
- 동행 통장 전체 지출 추이 다음에 나오는 실제 정산이 이루어지는 페이지 입니다.
- 정산을 하기 위해 버튼을 활성화 시키는 로직은 아래와 같습니다.

방장입장에서만 생각하자. 왜냐하면 참여자들은 신한 계좌가 없다고 생각해야 하기 때문입니다.
receive : 방장이 돈을 받아야 합니다.
send : 방장이 돈을 보내야 합니다.

- 랜덤 정산 버튼은 현재 상황에서 가장 최하위 순위이기 때문에 만들어는 두었으나 안보이게 해둔 상황입니다.